### PR TITLE
Update version number to the latest release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Test Data Builders are described in the book [Growing Object-Oriented Software, 
 
 You can download from Maven Central with the artifact coordinates:
 
-    com.natpryce:make-it-easy:4.0.0
+    com.natpryce:make-it-easy:4.0.1
 
 ## Example ##
 


### PR DESCRIPTION
Hi,

I noticed that the README doesn't state the newest library release (4.0.1) in Maven coordinates.
And I'm sure that 4.0.1 is stable. :-)

This pr changes that.

Regards.